### PR TITLE
Fix sweeping Discord core changes

### DIFF
--- a/Plugins/ChannelTabs/ChannelTabs.plugin.js
+++ b/Plugins/ChannelTabs/ChannelTabs.plugin.js
@@ -4,7 +4,7 @@
 * @source https://github.com/samfundev/BetterDiscordStuff/blob/master/Plugins/ChannelTabs/ChannelTabs.plugin.js
 * @donate https://paypal.me/samfun123
 * @authorId 76052829285916672
-* @version 2.6.9
+* @version 2.6.10
 */
 /*@cc_on
 @if (@_jscript)
@@ -54,7 +54,7 @@ module.exports = (() => {
 					github_username: "samfundev",
 				}
 			],
-			version: "2.6.9",
+			version: "2.6.10",
 			description: "Allows you to have multiple tabs and bookmark channels",
 			github: "https://github.com/samfundev/BetterDiscordStuff/blob/master/Plugins/ChannelTabs/",
 			github_raw: "https://raw.githubusercontent.com/samfundev/BetterDiscordStuff/master/Plugins/ChannelTabs/ChannelTabs.plugin.js"
@@ -64,14 +64,7 @@ module.exports = (() => {
 				title: "Fixed",
 				type: "fixed",
 				items: [
-					"Fixed tooltip causing a crash",
-				]
-			},
-			{
-				title: "Improved Stability",
-				type: "improved",
-				items: [
-					"Discord updates should cause less crashes/bugs",
+					"Fixed for Discord sweeping app changes",
 				]
 			}
 		]
@@ -3317,7 +3310,7 @@ module.exports = (() => {
 				
 				async patchAppView(promiseState)
 				{
-					const AppView = await ReactComponents.getComponent("Shakeable", ".app-2CXKsg");
+					const AppView = await ReactComponents.getComponent("Shakeable", ".app_de4237");
 					if(promiseState.cancelled) return;
 					Patcher.after(AppView.component.prototype, "render", (thisObject, _, returnValue) => {
 						returnValue.props.children = [


### PR DESCRIPTION
ChannelTabs plugin broke with recent Discord update; this PR fixes it.