### PR TITLE
Support auto-refreshing icons at plugin start

### DIFF
--- a/Plugins/ChannelTabs/ChannelTabs.plugin.js
+++ b/Plugins/ChannelTabs/ChannelTabs.plugin.js
@@ -3586,14 +3586,26 @@ module.exports = (() => {
 				updateFavIcon(fav) {
 					const updatedFav = fav
 					const iconUrl = fav.iconUrl.split('/')
-					const { url } = fav
+					const { channelId, url } = fav
 					const isDm = url.includes("@me")
 
 					
 					if (isDm) {
-						const userId = iconUrl[4] // get this differently
-						const user = UserStore.getUser(userId)
-						const newIconHash = user.avatar
+						const channel = ChannelStore.getChannel(channelId)
+						const { icon, recipients } = channel
+						let userId = ""
+						let newIconHash = ""
+						let urlStub = "icons"
+
+						if (recipients.length > 1) {
+							userId = channelId
+							newIconHash = icon
+							urlStub = "channel-icons"
+						} else {
+							userId = recipients[0]
+							const user = UserStore.getUser(userId)
+							newIconHash = user.avatar
+						}
 
 						if (newIconHash === null) {
 							updatedFav.iconUrl = ""
@@ -3601,7 +3613,7 @@ module.exports = (() => {
 						}
 
 						if (fav.iconUrl === "") {
-							updatedFav.iconUrl = "https://cdn.discordapp.com/icons/" + userId + "/" + newIconHash + ".webp?size=56"
+							updatedFav.iconUrl = "https://cdn.discordapp.com/" + urlStub + "/" + userId + "/" + newIconHash + ".webp?size=56"
 						} else {
 							iconUrl[5] = newIconHash + ".webp?size=56"
 							const newIconUrl = iconUrl.join("/")

--- a/Plugins/ChannelTabs/ChannelTabs.plugin.js
+++ b/Plugins/ChannelTabs/ChannelTabs.plugin.js
@@ -3589,21 +3589,42 @@ module.exports = (() => {
 					const { url } = fav
 					const isDm = url.includes("@me")
 
+					
 					if (isDm) {
-						const userId = iconUrl[4]
+						const userId = iconUrl[4] // get this differently
 						const user = UserStore.getUser(userId)
 						const newIconHash = user.avatar
-						iconUrl[5] = newIconHash + ".webp?size=56"
-						const newIconUrl = iconUrl.join("/")
-						updatedFav.iconUrl = newIconUrl
+
+						if (newIconHash === null) {
+							updatedFav.iconUrl = ""
+							return updatedFav
+						}
+
+						if (fav.iconUrl === "") {
+							updatedFav.iconUrl = "https://cdn.discordapp.com/icons/" + userId + "/" + newIconHash + ".webp?size=56"
+						} else {
+							iconUrl[5] = newIconHash + ".webp?size=56"
+							const newIconUrl = iconUrl.join("/")
+							updatedFav.iconUrl = newIconUrl
+						}
 					} else {
 						const splitUrl = url.split("/")
 
 						const guildId = splitUrl[2] 
-						const newIconHash = GuildStore.getGuild(guildId).icon 
-						iconUrl[5] = newIconHash + ".webp?"
-						const newIconUrl = iconUrl.join("/")
-						updatedFav.iconUrl = newIconUrl
+						const newIconHash = GuildStore.getGuild(guildId).icon
+
+						if (newIconHash === null) {
+							updatedFav.iconUrl = ""
+							return updatedFav
+						}
+
+						if (fav.iconUrl === "") {
+							updatedFav.iconUrl = "https://cdn.discordapp.com/icons/" + guildId + "/" + newIconHash + ".webp?"
+						} else {
+							iconUrl[5] = newIconHash + ".webp?"
+							const newIconUrl = iconUrl.join("/")
+							updatedFav.iconUrl = newIconUrl
+						}
 					}
 
 					return updatedFav

--- a/Plugins/ChannelTabs/ChannelTabs.plugin.js
+++ b/Plugins/ChannelTabs/ChannelTabs.plugin.js
@@ -2631,7 +2631,7 @@ module.exports = (() => {
 						:root {	
 							--channelTabs-tabHeight: 22px;
 							--channelTabs-favHeight: 22px;
-							--channelTabs-tabNameFontSize: 12px;
+							--channelTabs-tabNameFontSize: 16px;
 							--channelTabs-openTabSize: 18px;
 						}
 					`;
@@ -3582,6 +3582,32 @@ module.exports = (() => {
 						return this.getName() + "_new" + (user_id != null ? "_" + user_id : "");
 					}
 				}
+
+				updateFavIcon(fav) {
+					const updatedFav = fav
+					const iconUrl = fav.iconUrl.split('/')
+					const { url } = fav
+					const isDm = url.includes("@me")
+
+					if (isDm) {
+						const userId = iconUrl[4]
+						const user = UserStore.getUser(userId)
+						const newIconHash = user.avatar
+						iconUrl[5] = newIconHash + ".webp?size=56"
+						const newIconUrl = iconUrl.join("/")
+						updatedFav.iconUrl = newIconUrl
+					} else {
+						const splitUrl = url.split("/")
+
+						const guildId = splitUrl[2] 
+						const newIconHash = GuildStore.getGuild(guildId).icon 
+						iconUrl[5] = newIconHash + ".webp?"
+						const newIconUrl = iconUrl.join("/")
+						updatedFav.iconUrl = newIconUrl
+					}
+
+					return updatedFav
+				}
 				
 				loadSettings()
 				{					
@@ -3594,15 +3620,16 @@ module.exports = (() => {
 						this.settings = Utilities.loadSettings(this.getSettingsPath(), this.defaultVariables);
 					}
 					this.settings.favs = this.settings.favs.map(fav => {
-						if(fav.channelId === undefined){
-							const match = fav.url.match(/^\/channels\/[^\/]+\/(\d+)$/);
-							if(match) return Object.assign(fav, {channelId: match[1]});
+						const fav2 = this.updateFavIcon(fav);
+						if(fav2.channelId === undefined){
+							const match = fav2.url.match(/^\/channels\/[^\/]+\/(\d+)$/);
+							if(match) return Object.assign(fav2, {channelId: match[1]});
 						}
-						if (fav.groupId === undefined)
+						if (fav2.groupId === undefined)
 						{
-							return Object.assign(fav, {groupId: -1});
+							return Object.assign(fav2, {groupId: -1});
 						}
-						return fav;
+						return fav2;
 					});
 					this.saveSettings();
 				}

--- a/Plugins/ChannelTabs/ChannelTabs.plugin.js
+++ b/Plugins/ChannelTabs/ChannelTabs.plugin.js
@@ -2631,7 +2631,7 @@ module.exports = (() => {
 						:root {	
 							--channelTabs-tabHeight: 22px;
 							--channelTabs-favHeight: 22px;
-							--channelTabs-tabNameFontSize: 16px;
+							--channelTabs-tabNameFontSize: 12px;
 							--channelTabs-openTabSize: 18px;
 						}
 					`;


### PR DESCRIPTION
hi i threw this together for local use so you could probably do it better + add versioning and stuff

for the record i would totally not push code this sloppy to an actual work environment LOL

i noticed that when users or servers change the icon, since the info is snapshotted and saved to disk at the time of adding to the favourite, it's never updated and the link to the icon goes stale after the remote file is purged and the local client is refreshed. i wrote some garbage code to refresh the elements of each favourited item's icon url on plugin load