### PR TITLE
Fixed undefined username

### DIFF
--- a/Plugins/ChannelTabs/ChannelTabs.plugin.js
+++ b/Plugins/ChannelTabs/ChannelTabs.plugin.js
@@ -186,13 +186,20 @@ var Slider = getModule(
 	{ searchExports: true },
 );
 var NavShortcuts = getModule(byKeys("NAVIGATE_BACK", "NAVIGATE_FORWARD"));
-var [TitleBar, TitleBarKey] = Webpack.getWithKey(
+const [TitleBar, TitleBarKey] = (() => {
+    const [m, k] = Webpack.getWithKey(
 	byStrings(".PlatformTypes.WINDOWS&&(0,", "title"),
-	{
-		name: "TitleBar",
-		fatal: true,
-	},
-);
+        {name:"Toolbar", fatal:true}
+    ) ?? [];
+
+    if (typeof m?.[k] !== "function") {
+        const msg = "[ChannelTabs] ❌ Toolbar hook missing.";
+        console.error(msg);
+        BdApi.UI.showNotice(msg, {type:"error", timeout:10_000});
+        throw new Error(msg);
+    }
+    return [m, k];
+})();
 var IconUtilities = getModule(byKeys("getChannelIconURL"));
 var Icons = getModule((m) =>
 	Object.keys(m).some(

--- a/Plugins/ChannelTabs/ChannelTabs.plugin.js
+++ b/Plugins/ChannelTabs/ChannelTabs.plugin.js
@@ -1666,10 +1666,10 @@ var getCurrentName = (pathname = location.pathname) => {
 					.map((u) =>
 						!u.display_name && !u.global_name && u.bot
 							? `BOT (@${u.username})`
-							: RelationshipStore.getNickname(u.id) || u.display_name,
+							: RelationshipStore.getNickname(u.id) || u.display_name || u.global_name || u.username,
 					)
 					.join(", ") ||
-				`${channel.rawRecipients[0].display_name} (@${channel.rawRecipients[0].username})`
+				`${channel.rawRecipients[0].display_name || channel.rawRecipients[0].global_name || channel.rawRecipients[0].username} (@${channel.rawRecipients[0].username})`
 			);
 		else return pathname;
 	} else {

--- a/Plugins/ChannelTabs/ChannelTabs.plugin.js
+++ b/Plugins/ChannelTabs/ChannelTabs.plugin.js
@@ -96,9 +96,20 @@ function missingModule({ name = "<unnamed>", feature, fatal = false }) {
 		(site) => site.getFunctionName() === "getModule",
 	);
 	const trace = stack.filter((_, i) => i > index).join("\n");
-	console.warn(`Could not find '${name}' module.
-${trace}`);
-	if (fatal) throw `Could not find '${name}' module.`;
+	console[fatal ? "error" : "warn"](
+		`Could not find '${name}' module.
+${trace}`,
+	);
+	if (fatal) {
+		const content = BdApi.DOM.parseHTML(
+			`<span style="background: white; color: var(--color); padding: 1px 3px; margin-right: 3px; border-radius: 5px;">ChannelTabs</span> The critical module "${name}" could not be found. The plugin will not be able to load.`,
+			true,
+		);
+		BdApi.UI.showNotice(content, {
+			type: "error",
+		});
+		throw `Could not find '${name}' module.`;
+	}
 	if (feature != null) {
 		missingFeatures.push(feature);
 		if (dismissWarning) dismissWarning();
@@ -186,20 +197,10 @@ var Slider = getModule(
 	{ searchExports: true },
 );
 var NavShortcuts = getModule(byKeys("NAVIGATE_BACK", "NAVIGATE_FORWARD"));
-const [TitleBar, TitleBarKey] = (() => {
-    const [m, k] = Webpack.getWithKey(
-	byStrings(".PlatformTypes.WINDOWS&&(0,", "title"),
-        {name:"Toolbar", fatal:true}
-    ) ?? [];
-
-    if (typeof m?.[k] !== "function") {
-        const msg = "[ChannelTabs] ❌ Toolbar hook missing.";
-        console.error(msg);
-        BdApi.UI.showNotice(msg, {type:"error", timeout:10_000});
-        throw new Error(msg);
-    }
-    return [m, k];
-})();
+var [TitleBar, TitleBarKey] = Webpack.getWithKey(
+	byStrings(".PlatformTypes.WINDOWS&asdas&(0,", "title"),
+);
+if (!TitleBar) missingModule({ name: "TitleBar", fatal: true });
 var IconUtilities = getModule(byKeys("getChannelIconURL"));
 var Icons = getModule((m) =>
 	Object.keys(m).some(
@@ -1676,7 +1677,10 @@ var getCurrentName = (pathname = location.pathname) => {
 					.map((u) =>
 						!u.display_name && !u.global_name && u.bot
 							? `BOT (@${u.username})`
-							: RelationshipStore.getNickname(u.id) || u.display_name || u.global_name || u.username,
+							: RelationshipStore.getNickname(u.id) ||
+								u.display_name ||
+								u.global_name ||
+								u.username,
 					)
 					.join(", ") ||
 				`${channel.rawRecipients[0].display_name || channel.rawRecipients[0].global_name || channel.rawRecipients[0].username} (@${channel.rawRecipients[0].username})`

--- a/src/ChannelTabs/index.jsx
+++ b/src/ChannelTabs/index.jsx
@@ -1641,10 +1641,10 @@ const getCurrentName = (pathname = location.pathname) => {
 					.map((u) =>
 						!u.display_name && !u.global_name && u.bot
 							? `BOT (@${u.username})`
-							: RelationshipStore.getNickname(u.id) || u.display_name,
+							: RelationshipStore.getNickname(u.id) || u.display_name || u.global_name || u.username,
 					)
 					.join(", ") ||
-				`${channel.rawRecipients[0].display_name} (@${channel.rawRecipients[0].username})`
+				`${channel.rawRecipients[0].display_name || channel.rawRecipients[0].global_name || channel.rawRecipients[0].username} (@${channel.rawRecipients[0].username})`
 			);
 		else return pathname;
 	} else {

--- a/src/ChannelTabs/index.jsx
+++ b/src/ChannelTabs/index.jsx
@@ -132,13 +132,20 @@ const Slider = getModule(
 	{ searchExports: true },
 );
 const NavShortcuts = getModule(byKeys("NAVIGATE_BACK", "NAVIGATE_FORWARD"));
-const [TitleBar, TitleBarKey] = Webpack.getWithKey(
+const [TitleBar, TitleBarKey] = (() => {
+    const [m, k] = Webpack.getWithKey(
 	byStrings(".PlatformTypes.WINDOWS&&(0,", "title"),
-	{
-		name: "TitleBar",
-		fatal: true,
-	},
-);
+        {name:"Toolbar", fatal:true}
+    ) ?? [];
+
+    if (typeof m?.[k] !== "function") {
+        const msg = "[ChannelTabs] ❌ Toolbar hook missing.";
+        console.error(msg);
+        BdApi.UI.showNotice(msg, {type:"error", timeout:10_000});
+        throw new Error(msg);
+    }
+    return [m, k];
+})();
 const IconUtilities = getModule(byKeys("getChannelIconURL"));
 
 const Icons = getModule((m) =>


### PR DESCRIPTION
User name on tabs displays undefined in certain cases. This fixes it. example:
Recipient user data: {
  userId: '241334335884492810', 
  username: 'daddyboard', 
  displayName: undefined, 
  globalName: 'DaddyBoard', 
  isBot: undefined, 
  nickname: undefined
}
Final name for user 241334335884492810: undefined
Final result: undefined (@daddyboard)