### PR TITLE
Update ChannelTabs to work again

### DIFF
--- a/src/ChannelTabs/index.jsx
+++ b/src/ChannelTabs/index.jsx
@@ -133,7 +133,7 @@ const Slider = getModule(
 );
 const NavShortcuts = getModule(byKeys("NAVIGATE_BACK", "NAVIGATE_FORWARD"));
 const [TitleBar, TitleBarKey] = Webpack.getWithKey(
-	byStrings("data-windows", "title"),
+	byStrings(".PlatformTypes.WINDOWS&&(0,", "title"),
 	{
 		name: "TitleBar",
 		fatal: true,


### PR DESCRIPTION
fixed an issue where it didnt work

For all the people who don't know how github works:
Go look at [Files changed](https://github.com/samfundev/BetterDiscordStuff/pull/77/files)


For the devs:

Source for fix: https://discord.com/channels/947985618502307840/948653716532240435/1382034169877631096